### PR TITLE
feat(template): add reusable specs/templates/scripts to speed future builds [Droid‑assisted]

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,65 @@
+name: Export and Release
+
+on:
+  push:
+    tags:
+      - 'R*'
+      - 'v*'
+
+jobs:
+  export_and_release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install draw.io desktop
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y wget xvfb
+          DRAWIO_VER=28.0.6
+          wget -q https://github.com/jgraph/drawio-desktop/releases/download/v${DRAWIO_VER}/drawio-amd64-${DRAWIO_VER}.deb
+          sudo apt-get install -y ./drawio-amd64-${DRAWIO_VER}.deb
+
+      - name: Export diagrams (SVG/PNG/PDF A3/A2)
+        run: |
+          set -euo pipefail
+          mkdir -p dist
+          # DC Schematic exports
+          xvfb-run -a /opt/drawio/drawio --export --format svg --uncompressed --output diagrams/dc_schematic.drawio.svg diagrams/dc_schematic.drawio
+          xvfb-run -a /opt/drawio/drawio --export --format png --scale 2 --output diagrams/dc_schematic.drawio.png diagrams/dc_schematic.drawio
+          xvfb-run -a /opt/drawio/drawio --export --format pdf --pagesize A3 --uncompressed --output diagrams/dc_schematic_A3.drawio.pdf diagrams/dc_schematic.drawio
+          xvfb-run -a /opt/drawio/drawio --export --format pdf --pagesize A2 --uncompressed --output diagrams/dc_schematic_A2.drawio.pdf diagrams/dc_schematic.drawio
+          
+          # AC Schematic exports
+          xvfb-run -a /opt/drawio/drawio --export --format svg --uncompressed --output diagrams/ac_schematic.drawio.svg diagrams/ac_schematic.drawio
+          xvfb-run -a /opt/drawio/drawio --export --format png --scale 2 --output diagrams/ac_schematic.drawio.png diagrams/ac_schematic.drawio
+          xvfb-run -a /opt/drawio/drawio --export --format pdf --pagesize A3 --uncompressed --output diagrams/ac_schematic_A3.drawio.pdf diagrams/ac_schematic.drawio
+          xvfb-run -a /opt/drawio/drawio --export --format pdf --pagesize A2 --uncompressed --output diagrams/ac_schematic_A2.drawio.pdf diagrams/ac_schematic.drawio
+          
+          # Create zip with all exports
+          zip -j dist/H100-Electrical-${{ github.ref_name }}-exports.zip \
+            diagrams/dc_schematic.drawio.svg \
+            diagrams/dc_schematic.drawio.png \
+            diagrams/dc_schematic_A3.drawio.pdf \
+            diagrams/dc_schematic_A2.drawio.pdf \
+            diagrams/ac_schematic.drawio.svg \
+            diagrams/ac_schematic.drawio.png \
+            diagrams/ac_schematic_A3.drawio.pdf \
+            diagrams/ac_schematic_A2.drawio.pdf
+
+      - name: Create GitHub release and upload assets
+        uses: softprops/action-gh-release@v2
+        with:
+          name: H100 Electrical ${{ github.ref_name }}
+          body: |
+            Automated release for ${{ github.ref_name }}
+            
+            Includes exported diagrams (SVG/PNG + A3/A2 PDFs) zipped.
+            Source revision dates embedded as of tag time.
+          files: |
+            dist/*.zip
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,34 @@
+# Node dependencies
+node_modules/
+
+# Build outputs
+dist/
+
+# Logs
+*.log
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+
+# OS files
+.DS_Store
+Thumbs.db
+
+# Editor directories and files
+.idea/
+.vscode/
+*.swp
+*.swo
+
+# Environment variables
+.env
+.env.local
+
+# Temporary files
+*.tmp
+.cache/
+
+# Generated exports (keep templates)
+diagrams/*.svg
+diagrams/*.png
+diagrams/*.pdf

--- a/TEMPLATE_USAGE.md
+++ b/TEMPLATE_USAGE.md
@@ -1,0 +1,78 @@
+# Camper Electrical Template — Usage Guide
+
+Speed-run future camper builds with this lightweight templating system.
+
+---
+
+## 1 · Edit `specs.yaml`
+Update the YAML with your project-specific data:
+
+- Batteries (count, model, chemistry)  
+- BMS & main contactor  
+- Solar array details (panel count/wattage, wiring)  
+- Charge equipment (MPPT, DC-DC, inverter/charger)  
+- Wire gauges, run lengths, region, etc.  
+
+Optional: add `updatedDate: YYYY-MM-DD` to stamp generated docs.
+
+---
+
+## 2 · Validate the spec
+```bash
+npm ci          # install dev-deps (Ajv, Handlebars, etc.)
+npm run validate
+```
+`validate-specs.mjs` checks `specs.yaml` against `specs.schema.json`.
+
+---
+
+## 3 · Generate docs & BOM
+```bash
+npm run build
+```
+This renders **from templates**:
+
+- `docs/installation.md`  
+- `docs/safety.md`  
+- `bom/bom.csv`
+
+All values are substituted from `specs.yaml`.
+
+---
+
+## 4 · Export diagrams
+1. Open the `.drawio` sources (`diagrams/*.drawio`)  
+2. Update Contents box, fuse ratings, labels, wire-gauge pills, etc.  
+3. Export locally **or** let CI handle it.
+
+Local export example (Linux/Mac):
+```bash
+/opt/drawio/drawio --export \
+  --format svg --uncompressed \
+  --output diagrams/dc_schematic.drawio.svg \
+  diagrams/dc_schematic.drawio
+```
+Repeat for PNG + A3/A2 PDF as needed.
+
+CI export: push a tag (e.g. `R1.5` or `v1.5`) and the GitHub Actions workflow will:
+- Install draw.io headless
+- Export SVG/PNG + A3/A2 PDFs
+- Zip them (`dist/<tag>-exports.zip`)
+- Publish a GitHub Release with the asset attached
+
+---
+
+## 5 · Package docs & BOM (optional)
+```bash
+npm run package
+```
+Creates `dist/docs-and-bom.zip` containing the freshly rendered docs and BOM.
+
+---
+
+## Turning this repo into a GitHub template
+1. Go to **Settings → General**  
+2. Enable **Template repository**  
+3. For a new build, click **Use this template** → give it a name → clone → update `specs.yaml` → follow steps 1-5.
+
+Happy building! 🔧⚡️

--- a/bom/templates/bom.template.csv
+++ b/bom/templates/bom.template.csv
@@ -1,0 +1,23 @@
+Category,Brand,Model,Description,Qty,Notes
+Battery,,{{specs.batteries.model}},12V battery module,{{specs.batteries.count}},Chemistry: {{specs.batteries.chemistry}}
+BMS,,{{specs.bms.model}},External BMS with balancing,1,Controls main contactor
+Main Contactor,,{{specs.bms.control}},High-current DC contactor,1,Fused coil supply
+Shunt,Victron,SmartShunt 500A,Battery monitor shunt with Bluetooth,1,
+MPPT,{{#if specs.pv.controller.model}}Victron{{/if}},{{specs.pv.controller.model}},Solar charge controller,1,Sized for {{specs.pv.panels.count}}x{{specs.pv.panels.watt}}W ({{specs.pv.panels.wiring}})
+DC-DC Charger,Victron,{{specs.alternator.dcdc.model}},Vehicle alternator to house bank charger,1,
+Inverter/Charger,Victron,{{specs.inverter.model}},AC inverter/charger,1,Feeds AC distribution
+PV Isolator,Generic,DC isolator,PV string isolator,1,Rated per array voltage/current
+12V Fuse Block,Blue Sea,{{specs.low_voltage_distribution.fuse_block}},12-circuit fuse block with negative bus,1,
+Bus Bar (+),Blue Sea,{{specs.low_voltage_distribution.bus_bars.positive}},Positive bus bar,1,Capacity >= 250A
+Bus Bar (-),Blue Sea,{{specs.low_voltage_distribution.bus_bars.negative}},Negative bus bar,1,Capacity >= 250A
+Fuse - Battery,MEGA,100A,Between battery + and contactor,{{specs.batteries.count}},
+Fuse - Inverter,Class T,200A,Between + bus and inverter,1,
+Fuse - Distribution,MIDI,60A,Between + bus and 12V fuse block,1,
+Fuse - MPPT Output,MEGA/MIDI,60A,Between + bus and MPPT,1,Adjust per controller
+Fuse - DC-DC Output,MEGA/MIDI,60A,Between + bus and DC-DC,1,Adjust per charger
+Solar Panel,Generic,{{specs.pv.panels.watt}}W,PV module,{{specs.pv.panels.count}},{{specs.pv.panels.wiring}} string
+PV Cable,Generic,10 AWG (6 mm²),UV-rated PV cable (red/black),10 m,Length per layout
+Lugs and Heatshrink,Generic,As required,For {{specs.wiring.main_cable}} and {{specs.wiring.branch_cable}} terminations,1 set,
+Main Cabling,Generic,{{specs.wiring.main_cable}},Battery/contactor/inverter runs,As req,Length per layout
+Branch Cabling,Generic,{{specs.wiring.branch_cable}},MPPT and DC-DC runs,As req,Length per layout
+MC4 Connectors,Generic,MC4 pair,Solar connectors,{{specs.pv.panels.count}} pairs,

--- a/docs/templates/installation.template.md
+++ b/docs/templates/installation.template.md
@@ -1,0 +1,39 @@
+# {{specs.project}} – Installation ({{specs.version}})
+
+Updated: {{specs.updatedDate}}{{#unless specs.updatedDate}}(set specs.updatedDate in specs.yaml){{/unless}}
+
+Summary
+- Batteries: {{specs.batteries.model}} (x{{specs.batteries.count}})
+- BMS: {{specs.bms.model}} (controls {{specs.bms.control}})
+- MPPT: {{specs.pv.controller.model}}
+- DC-DC: {{specs.alternator.dcdc.model}}
+- Inverter/Charger: {{specs.inverter.model}}
+- Solar: {{specs.pv.panels.count}} × {{specs.pv.panels.watt}} W ({{specs.pv.panels.wiring}})
+- 12 V Distribution: {{specs.low_voltage_distribution.fuse_block}}, bus bars {{specs.low_voltage_distribution.bus_bars.positive}} / {{specs.low_voltage_distribution.bus_bars.negative}}
+
+Wiring Notes
+- Main runs: {{specs.wiring.main_cable}} for battery / contactor / inverter.
+- MPPT / DC-DC: {{specs.wiring.branch_cable}} typical (adjust per length and current).
+- Confirm device fuse sizes per manufacturer; adjust for region {{specs.region}}.
+
+PV ({{specs.pv.panels.count}} × {{specs.pv.panels.watt}} W, {{specs.pv.panels.wiring}})
+1. Wire panels per configuration (roof → gland → PV isolator → MPPT IN).
+2. Confirm MPPT voltage/current limits are respected.
+
+SmartShunt
+- Battery negatives to battery side; system negatives to load side.
+- Torque per manufacturer.
+
+Contactor & BMS
+1. Place main contactor in battery positive path before + bus.
+2. Power coil from protected fused feed.
+3. BMS output drives coil via control relay if required.
+4. Configure LVD / HVD / Temp in BMS app.
+
+Commissioning
+1. Verify polarity and torque on all terminations.
+2. Close PV isolator and confirm MPPT sees array Voc.
+3. Enable BMS, close contactor (pre-charge if applicable).
+4. Power inverter/charger and verify AC output with no loads.
+5. Check charge sources current / voltage.
+6. Record baseline values in shunt/monitoring.

--- a/docs/templates/safety.template.md
+++ b/docs/templates/safety.template.md
@@ -1,0 +1,26 @@
+# Safety ({{specs.version}})
+
+Updated: {{specs.updatedDate}}{{#unless specs.updatedDate}}(set specs.updatedDate in specs.yaml){{/unless}}
+
+General  
+- Follow device manuals and local electrical regulations.  
+- De-energize before service; verify absence of voltage with a meter; wear appropriate PPE.  
+
+Protection  
+- Battery positives individually fused per battery model/current.  
+- Main contactor (e.g., {{specs.bms.control}}) functions as the primary system disconnect under BMS control.  
+- Inverter protected by a Class-T fuse sized for the model and cable gauge.  
+- Distribution, MPPT, and DC-DC circuits protected by appropriately sized fuses or breakers.  
+
+BMS / Contactor Logic  
+- BMS low/high-voltage or temperature events open the main contactor.  
+- Contactor coil feed must be fused and taken from a protected supply.  
+- Optional: include a manual emergency-stop switch in the coil circuit.  
+
+Grounding / Bonding  
+- Follow manufacturer guidance for DC negative / AC earth bonding.  
+- RCD/MCB on AC distribution; shore-power inlet protected per local code.  
+
+PV  
+- PV isolator must be DC-rated; treat connectors as live whenever exposed to sunlight.  
+- Use UV-rated PV cable and appropriate connectors (e.g., MC4).  

--- a/package.json
+++ b/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "camper-electrical-template",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "validate": "node scripts/validate-specs.mjs",
+    "build": "node scripts/generate-from-specs.mjs",
+    "package": "mkdir -p dist && zip -j dist/docs-and-bom.zip docs/installation.md docs/safety.md bom/bom.csv"
+  },
+  "devDependencies": {
+    "ajv": "^8.17.1",
+    "handlebars": "^4.7.8",
+    "yaml": "^2.4.2",
+    "yargs": "^17.7.2"
+  }
+}

--- a/scripts/generate-from-specs.mjs
+++ b/scripts/generate-from-specs.mjs
@@ -1,0 +1,52 @@
+#!/usr/bin/env node
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import YAML from 'yaml';
+import Handlebars from 'handlebars';
+import yargs from 'yargs';
+import { hideBin } from 'yargs/helpers';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+const argv = yargs(hideBin(process.argv))
+  .option('spec', { type: 'string', default: 'specs.yaml' })
+  .option('outDocsDir', { type: 'string', default: 'docs' })
+  .option('outBomDir', { type: 'string', default: 'bom' })
+  .argv;
+
+const loadYaml = (p) => YAML.parse(fs.readFileSync(p, 'utf8'));
+const compile = (tplPath) => Handlebars.compile(fs.readFileSync(tplPath, 'utf8'));
+const write = (p, content) => {
+  fs.mkdirSync(path.dirname(p), { recursive: true });
+  fs.writeFileSync(p, content);
+};
+
+// Helpers
+Handlebars.registerHelper('upper', (s) => String(s).toUpperCase());
+Handlebars.registerHelper('join', (arr, sep) => Array.isArray(arr) ? arr.join(sep) : '');
+
+(function main() {
+  const specsPath = path.resolve(argv.spec);
+  if (!fs.existsSync(specsPath)) {
+    console.error(`Specs file not found: ${specsPath}`);
+    process.exit(1);
+  }
+  const specs = loadYaml(specsPath);
+
+  // Render docs
+  const instTpl = compile(path.join(__dirname, '..', 'docs', 'templates', 'installation.template.md'));
+  const safetyTpl = compile(path.join(__dirname, '..', 'docs', 'templates', 'safety.template.md'));
+  const installation = instTpl({ specs });
+  const safety = safetyTpl({ specs });
+  write(path.join(argv.outDocsDir, 'installation.md'), installation);
+  write(path.join(argv.outDocsDir, 'safety.md'), safety);
+
+  // Render BOM
+  const bomTpl = compile(path.join(__dirname, '..', 'bom', 'templates', 'bom.template.csv'));
+  const bom = bomTpl({ specs });
+  write(path.join(argv.outBomDir, 'bom.csv'), bom);
+
+  console.log('Generated docs/installation.md, docs/safety.md, bom/bom.csv from', specsPath);
+})();

--- a/scripts/validate-specs.mjs
+++ b/scripts/validate-specs.mjs
@@ -1,0 +1,19 @@
+#!/usr/bin/env node
+import fs from 'fs';
+import Ajv from 'ajv';
+import YAML from 'yaml';
+
+const schema = JSON.parse(fs.readFileSync('specs.schema.json', 'utf8'));
+const specs = YAML.parse(fs.readFileSync('specs.yaml', 'utf8'));
+
+const ajv = new Ajv({ allErrors: true });
+const validate = ajv.compile(schema);
+const ok = validate(specs);
+
+if (!ok) {
+  console.error('specs.yaml validation failed:');
+  console.error(validate.errors);
+  process.exit(1);
+}
+
+console.log('specs.yaml is valid.');

--- a/specs.schema.json
+++ b/specs.schema.json
@@ -1,0 +1,113 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Camper Electrical Specs",
+  "type": "object",
+  "required": ["project", "version", "region", "batteries", "bms", "pv", "inverter"],
+  "properties": {
+    "project": {"type": "string"},
+    "version": {"type": "string"},
+    "region": {"type": "string"},
+    "batteries": {
+      "type": "object",
+      "required": ["count", "model"],
+      "properties": {
+        "count": {"type": "integer", "minimum": 1},
+        "model": {"type": "string"},
+        "chemistry": {"type": "string"}
+      }
+    },
+    "bms": {
+      "type": "object",
+      "required": ["model"],
+      "properties": {
+        "model": {"type": "string"},
+        "control": {"type": "string"}
+      }
+    },
+    "shunt": {"type": "object", "properties": {"model": {"type": "string"}}},
+    "pv": {
+      "type": "object",
+      "required": ["panels", "controller"],
+      "properties": {
+        "panels": {
+          "type": "object",
+          "required": ["count", "watt", "wiring"],
+          "properties": {
+            "count": {"type": "integer", "minimum": 1},
+            "watt": {"type": "integer", "minimum": 1},
+            "wiring": {"type": "string", "enum": ["series", "parallel", "2S2P", "custom"]}
+          }
+        },
+        "controller": {
+          "type": "object",
+          "required": ["model"],
+          "properties": {"model": {"type": "string"}}
+        }
+      }
+    },
+    "alternator": {
+      "type": "object",
+      "properties": {
+        "dcdc": {"type": "object", "properties": {"model": {"type": "string"}}}
+      }
+    },
+    "inverter": {
+      "type": "object",
+      "required": ["model"],
+      "properties": {"model": {"type": "string"}}
+    },
+    "low_voltage_distribution": {
+      "type": "object",
+      "properties": {
+        "fuse_block": {"type": "string"},
+        "bus_bars": {
+          "type": "object",
+          "properties": {"positive": {"type": "string"}, "negative": {"type": "string"}}
+        }
+      }
+    },
+    "wiring": {
+      "type": "object",
+      "properties": {
+        "main_cable": {"type": "string"},
+        "branch_cable": {"type": "string"},
+        "runs": {
+          "type": "object",
+          "properties": {
+            "pv_to_mppt": {"type": "string"},
+            "alt_to_battery": {"type": "string"},
+            "water_pump": {"type": "string"},
+            "general": {"type": "string"}
+          }
+        }
+      }
+    },
+    "outputs": {
+      "type": "object",
+      "properties": {
+        "ac_outlets": {"type": "integer", "minimum": 0},
+        "dc_outlets": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "type": {"type": "string"}
+            },
+            "required": ["type"]
+          }
+        },
+        "loads": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "name": {"type": "string"},
+              "current": {"type": "string"}
+            },
+            "required": ["name", "current"]
+          }
+        }
+      }
+    }
+  }
+}

--- a/specs.yaml
+++ b/specs.yaml
@@ -1,0 +1,57 @@
+# Project specs for templated generation
+project: H100 Camper Build
+version: R1.4c
+region: AU/NZ
+
+batteries:
+  count: 2
+  model: Valence U27-12
+  chemistry: LiFePO4
+
+bms:
+  model: JK BMS 8S 2A
+  control: TE EV200 (12V coil)
+
+shunt:
+  model: Victron SmartShunt 500A
+
+pv:
+  panels:
+    count: 2
+    watt: 200
+    wiring: series
+  controller:
+    model: Victron SmartSolar 100/30
+
+alternator:
+  dcdc:
+    model: Victron Orion-Tr Smart 12/12-30A (isolated)
+
+inverter:
+  model: Victron MultiPlus 12/2000
+
+low_voltage_distribution:
+  fuse_block: Blue Sea 5029
+  bus_bars:
+    positive: Blue Sea 2104
+    negative: Blue Sea 2105
+
+wiring:
+  main_cable: 2/0 AWG (70-95 mm2)
+  branch_cable: 6 AWG (13 mm2)
+  runs:
+    pv_to_mppt: 3m
+    alt_to_battery: 1.5m
+    water_pump: 3m
+    general: 1m
+
+outputs:
+  ac_outlets: 1
+  dc_outlets:
+    - type: 12V/USB A+C
+    - type: 12V/USB A+C
+  loads:
+    - name: water pump
+      current: 10A
+    - name: lights
+      current: 5A


### PR DESCRIPTION
This PR introduces a lightweight templating system to accelerate future camper electrical projects.

What’s included
- specs.yaml: single source of truth for project parameters
- specs.schema.json + npm run validate (Ajv) to sanity‑check inputs
- Handlebars templates for docs and BOM
  - docs/templates/installation.template.md
  - docs/templates/safety.template.md
  - bom/templates/bom.template.csv
- Generator scripts (Node)
  - scripts/validate-specs.mjs
  - scripts/generate-from-specs.mjs
- package.json with scripts (validate, build, package)
- TEMPLATE_USAGE.md quickstart and .gitignore

Usage (TL;DR)
1) Edit specs.yaml
2) npm ci && npm run validate
3) npm run build  → renders docs + BOM
4) Push a tag (e.g., R1.5) to trigger CI export & release (from the separate release workflow PR)

Notes
- Non‑intrusive: existing docs/diagrams are unchanged
- This is the foundation; we can later extend to auto‑update draw.io Contents blocks or wire labels if desired

— Droid‑assisted PR

---
**Factory Session:** https://app.factory.ai/sessions/DJXYqVuZHWVDFQEvRO28 (created by OutOdaBlox)